### PR TITLE
make type checkers happy

### DIFF
--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -21,6 +21,7 @@ jobs:
           poetry run flake8 --filename=*.py option/
           poetry run black --check .
           poetry run isort --check-only --profile black .
+          poetry run mypy option/
 
   pytest:
     runs-on: ubuntu-latest

--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -21,7 +21,7 @@ jobs:
           poetry run flake8 --filename=*.py option/
           poetry run black --check .
           poetry run isort --check-only --profile black .
-          poetry run mypy option/
+          poetry run mypy option/ tests/
 
   pytest:
     runs-on: ubuntu-latest

--- a/option/option.py
+++ b/option/option.py
@@ -55,7 +55,7 @@ class Some(Generic[T]):
     def unwrap(self) -> T:
         return self._value
 
-    def unwrap_or(self, _: T) -> T:
+    def unwrap_or(self, _: object) -> T:
         return self._value
 
     def unwrap_or_else(self, _: Callable[[], T]) -> T:
@@ -87,20 +87,20 @@ class Nothing:
     def is_some(self) -> bool:
         return False
 
-    def is_some_and(self, f: Callable[[T], bool]) -> bool:
+    def is_some_and(self, f: Callable[[Any], bool]) -> bool:
         return False
 
     @property
     def value(self) -> None:
         return None
 
-    def map(self, _: Callable) -> "Nothing":
+    def map(self, _: Callable[[Any], U]) -> "Nothing":
         return self
 
-    def map_or(self, default: U, _: Callable) -> U:
+    def map_or(self, default: U, _: Callable[[Any], U]) -> U:
         return default
 
-    def map_or_else(self, default: Callable[[], U], _: Callable[[T], U]) -> U:
+    def map_or_else(self, default: Callable[[], U], _: Callable[[Any], U]) -> U:
         return default()
 
     def or_else(self, f: Callable[[], Some[T]]) -> Some[T]:
@@ -109,7 +109,7 @@ class Nothing:
     def unwrap(self) -> NoReturn:
         raise UnwrapError(self, "Called `Option.unwrap()` on an `Nothing` value")
 
-    def unwrap_or(self, default: T) -> T:
+    def unwrap_or(self, default: U) -> U:
         return default
 
     def unwrap_or_else(self, default: Callable[[], T]) -> T:


### PR DESCRIPTION
This PR will Fix #2 and some type errors.

The following three types of type errors are currently occurring:
- Caused by incomplete types.
  - This is the one pointed out in #2. Bare “Callable”s correspond to it. 
- Due to covariance.
  - If A is a subtype of B, it seems natural that Option[A] is also a subtype of Option[B]. So we use `T = TypeVar("T", covariant=True)` for `class Some(Generic[T]):`. However, because covariant type variable cannot be used in parameter type, we cannot use `def unwrap_or(self, default: T) -> T:`.
- Due to Lack of runtime annotation
  - Think about `Nothing().map(lambda x: x + 1)`. The problem is that the type of `lambda x: x + 1` is not clear.
It would be nice if we could annotate this lambda expression with the type directly, or annotate Nothing directly, but that is not possible (of course it is possible via a temporary variable, but Ruff does not allow lambdas to be put into temporary variables).

To address these issues, I did the followings:
- Eliminated incomplete types.
- Excluded `T` from the function arguments. In particular, I used `Any` instead.

